### PR TITLE
Show price when items is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Prop `showWhenUnavailable` to the following blocks `product-list-price`, `product-selling-price`, `product-spot-price`, `product-spot-price-savings`, `product-price-savings`, `product-list-price-range`, and `product-selling-price-range` to render them even when product is unavailable.
+
 ## [1.22.0] - 2021-06-24
 ### Added
 - CSS handles modifiers to `paymentSystemName` and `installmentsNumber` handles.

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,21 @@ The block `product-price-savings` has two additional props:
 | `percentageStyle` | `locale` or `compact` | Set to `compact` if you want to remove the white space between the number and the percent sign. It uses pattern provided by the current locale as default. | `locale` |
 | `minimumPercentage` | `number` | Set the minimum value for the percentage value display. If not informed, it always appears. Example: `10`, savings under or equal 10% will not show up. | `0` |
 
+The following blocks `product-list-price`, `product-selling-price`, `product-spot-price`, `product-spot-price-savings`, `product-price-savings`, `product-list-price-range`, and `product-selling-price-range` have an additional prop:
+
+| Prop name    | Type       | Description                                              | Default value       |
+| :----------: | :--------: | :------------------------------------------------------: | :-----------------: |
+| `showWhenUnavailable`   | `boolean`    | Renders the block even when the product is unavailable. | `false`  |
+
+For example:
+
+```json
+"product-selling-price#summary": {
+  "props": {
+    "showWhenUnavailable": true
+  }
+},
+```
 
 If you are using the asynchronous price feature, you can take advantage of the `product-price-suspense` and its props:
 
@@ -287,6 +302,7 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `installments` |
 | `interestRate` |
 | `listPrice'` |
+| `listPrice--isUnavailable` |
 | `listPriceRangeMaxValue` |
 | `listPriceRangeMaxWithTax` |
 | `listPriceRangeMinValue` |
@@ -294,6 +310,7 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `listPriceRangeUniqueValue` |
 | `listPriceRangeUniqueWithTax` |
 | `listPriceRange` |
+| `listPriceRange--isUnavailable` | 
 | `listPriceValue` |
 | `listPriceWithTax` | 
 | `newPriceValue` |
@@ -304,10 +321,12 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `savingsValue` |
 | `savingsWithTax` |
 | `savings` |
+| `savings--isUnavailable` | 
 | `sellerName` |
 | `sellerNameContainer` |
 | `sellerNameContainer--isDefaultSeller` |
 | `sellingPrice--hasListPrice` |
+| `sellingPrice--isUnavailable` |
 | `sellingPriceRangeMaxValue` |
 | `sellingPriceRangeMaxWithTax` |
 | `sellingPriceRangeMinValue` |
@@ -315,15 +334,18 @@ To apply CSS customization in this and other blocks, follow the instructions giv
 | `sellingPriceRangeUniqueValue` |
 | `sellingPriceRangeUniqueWithTax` |
 | `sellingPriceRange` |
+| `sellingPriceRange--isUnavailable` |
 | `sellingPriceValue` |
 | `sellingPriceWithTax` | 
 | `sellingPrice` |
 | `spotPriceSavingsPercentage` | 
 | `spotPriceSavingsValue` | 
 | `spotPriceSavingsWithTax` | 
-| `spotPriceSavings` | 
+| `spotPriceSavings` |
+| `spotPriceSavings--isUnavailable` | 
 | `spotPriceValue` |
 | `spotPrice` |
+| `spotPrice--isUnavailable` |
 | `taxPercentage` |
 
 <!-- DOCS-IGNORE:start -->

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -35,21 +35,26 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function ListPrice({
   message = messages.default.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -73,8 +78,14 @@ function ListPrice({
     return null
   }
 
+  const containerClasses = withModifiers('listPrice', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   return (
-    <span className={handles.listPrice}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={message}
         markers={markers}

--- a/react/ListPrice.tsx
+++ b/react/ListPrice.tsx
@@ -6,6 +6,7 @@ import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'listPrice',
@@ -51,10 +52,13 @@ function ListPrice({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -79,9 +83,7 @@ function ListPrice({
   }
 
   const containerClasses = withModifiers('listPrice', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   return (

--- a/react/ListPriceRange.tsx
+++ b/react/ListPriceRange.tsx
@@ -6,6 +6,7 @@ import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'listPriceRange',
@@ -77,10 +78,13 @@ function ListPriceRange({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -91,9 +95,7 @@ function ListPriceRange({
   const maxPriceWithTax = maxPrice + maxPrice * commercialOffer.taxPercentage
 
   const containerClasses = withModifiers('listPriceRange', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   if (hasRange) {

--- a/react/ListPriceRange.tsx
+++ b/react/ListPriceRange.tsx
@@ -47,6 +47,7 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function ListPriceRange({
@@ -54,8 +55,9 @@ function ListPriceRange({
   noRangeMessage = messages.noRangeMessageDefault.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
 
   const priceRange = productContextValue?.product?.priceRange
@@ -75,7 +77,10 @@ function ListPriceRange({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -85,9 +90,15 @@ function ListPriceRange({
   const minPriceWithTax = minPrice + minPrice * commercialOffer.taxPercentage
   const maxPriceWithTax = maxPrice + maxPrice * commercialOffer.taxPercentage
 
+  const containerClasses = withModifiers('listPriceRange', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   if (hasRange) {
     return (
-      <span className={handles.listPriceRange}>
+      <span className={containerClasses}>
         <IOMessageWithMarkers
           message={message}
           markers={markers}
@@ -132,7 +143,7 @@ function ListPriceRange({
   }
 
   return (
-    <span className={handles.listPriceRange}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={noRangeMessage}
         markers={markers}

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -65,6 +65,7 @@ interface Props {
   minimumPercentage?: number
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function Savings({
@@ -73,8 +74,9 @@ function Savings({
   minimumPercentage = 0,
   percentageStyle = 'locale',
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const { formatNumber } = useIntl()
   const productContextValue = useProduct()
   const productSummaryValue = ProductSummaryContext.useProductSummary()
@@ -85,7 +87,7 @@ function Savings({
 
   if (
     !commercialOffer ||
-    commercialOffer?.AvailableQuantity <= 0 ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0) ||
     productSummaryValue?.isLoading
   ) {
     return null
@@ -103,8 +105,14 @@ function Savings({
     return null
   }
 
+  const containerClasses = withModifiers('savings', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   return (
-    <span className={handles.savings}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={message}
         markers={markers}

--- a/react/Savings.tsx
+++ b/react/Savings.tsx
@@ -7,6 +7,7 @@ import { IOMessageWithMarkers } from 'vtex.native-types'
 import { ProductSummaryContext } from 'vtex.product-summary-context'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'savings',
@@ -85,11 +86,13 @@ function Savings({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0) ||
-    productSummaryValue?.isLoading
-  ) {
+  if (!commercialOffer || productSummaryValue?.isLoading) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -106,9 +109,7 @@ function Savings({
   }
 
   const containerClasses = withModifiers('savings', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   return (

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -35,12 +35,14 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function SellingPrice({
   message = messages.default.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, {
     classes,
@@ -52,7 +54,10 @@ function SellingPrice({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -78,6 +83,9 @@ function SellingPrice({
     hasListPrice ? 'hasListPrice' : '',
     hasMeasurementUnit ? 'hasMeasurementUnit' : '',
     hasUnitMultiplier ? 'hasUnitMultiplier' : '',
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
   ])
 
   return (

--- a/react/SellingPrice.tsx
+++ b/react/SellingPrice.tsx
@@ -6,6 +6,7 @@ import { IOMessageWithMarkers } from 'vtex.native-types'
 import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'sellingPrice',
@@ -54,10 +55,13 @@ function SellingPrice({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -83,9 +87,7 @@ function SellingPrice({
     hasListPrice ? 'hasListPrice' : '',
     hasMeasurementUnit ? 'hasMeasurementUnit' : '',
     hasUnitMultiplier ? 'hasUnitMultiplier' : '',
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   return (

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -49,6 +49,7 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function SellingPriceRange({
@@ -56,8 +57,9 @@ function SellingPriceRange({
   noRangeMessage = messages.noRangeMessageDefault.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
 
   const priceRange = productContextValue?.product?.priceRange
@@ -70,7 +72,10 @@ function SellingPriceRange({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -84,9 +89,15 @@ function SellingPriceRange({
     commercialOffer.PriceWithoutDiscount +
     commercialOffer.PriceWithoutDiscount * commercialOffer.taxPercentage
 
+  const containerClasses = withModifiers('sellingPriceRange', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   if (hasRange) {
     return (
-      <span className={handles.sellingPriceRange}>
+      <span className={containerClasses}>
         <IOMessageWithMarkers
           message={message}
           markers={markers}
@@ -147,7 +158,7 @@ function SellingPriceRange({
   }
 
   return (
-    <span className={handles.sellingPriceRange}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={noRangeMessage}
         markers={markers}

--- a/react/SellingPriceRange.tsx
+++ b/react/SellingPriceRange.tsx
@@ -6,6 +6,7 @@ import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'sellingPriceRange',
@@ -72,10 +73,13 @@ function SellingPriceRange({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -90,9 +94,7 @@ function SellingPriceRange({
     commercialOffer.PriceWithoutDiscount * commercialOffer.taxPercentage
 
   const containerClasses = withModifiers('sellingPriceRange', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   if (hasRange) {

--- a/react/SpotPrice.tsx
+++ b/react/SpotPrice.tsx
@@ -6,6 +6,7 @@ import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = ['spotPrice', 'spotPriceValue'] as const
 
@@ -42,10 +43,13 @@ function SpotPrice({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -57,9 +61,7 @@ function SpotPrice({
   }
 
   const containerClasses = withModifiers('spotPrice', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   return (

--- a/react/SpotPrice.tsx
+++ b/react/SpotPrice.tsx
@@ -26,21 +26,26 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function SpotPrice({
   message = messages.default.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -51,8 +56,14 @@ function SpotPrice({
     return null
   }
 
+  const containerClasses = withModifiers('spotPrice', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   return (
-    <span className={handles.spotPrice}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={message}
         markers={markers}

--- a/react/SpotPriceSavings.tsx
+++ b/react/SpotPriceSavings.tsx
@@ -33,21 +33,26 @@ interface Props {
   markers?: string[]
   /** Used to override default CSS handles */
   classes?: CssHandlesTypes.CustomClasses<typeof CSS_HANDLES>
+  showWhenUnavailable?: boolean
 }
 
 function SpotPriceSavings({
   message = messages.default.id,
   markers = [],
   classes,
+  showWhenUnavailable = false,
 }: Props) {
-  const { handles } = useCssHandles(CSS_HANDLES, { classes })
+  const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const productContextValue = useProduct()
 
   const seller = getDefaultSeller(productContextValue?.selectedItem?.sellers)
 
   const commercialOffer = seller?.commertialOffer
 
-  if (!commercialOffer || commercialOffer?.AvailableQuantity <= 0) {
+  if (
+    !commercialOffer ||
+    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
+  ) {
     return null
   }
 
@@ -65,8 +70,14 @@ function SpotPriceSavings({
     return null
   }
 
+  const containerClasses = withModifiers('spotPriceSavings', [
+    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
+      ? 'isUnavailable'
+      : '',
+  ])
+
   return (
-    <span className={handles.spotPriceSavings}>
+    <span className={containerClasses}>
       <IOMessageWithMarkers
         message={message}
         markers={markers}

--- a/react/SpotPriceSavings.tsx
+++ b/react/SpotPriceSavings.tsx
@@ -6,6 +6,7 @@ import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
 import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import { getDefaultSeller } from './modules/seller'
+import { hideWhenUnavailable } from './modules/hideWhenUnavailable'
 
 const CSS_HANDLES = [
   'spotPriceSavings',
@@ -49,10 +50,13 @@ function SpotPriceSavings({
 
   const commercialOffer = seller?.commertialOffer
 
-  if (
-    !commercialOffer ||
-    (!showWhenUnavailable && commercialOffer?.AvailableQuantity <= 0)
-  ) {
+  if (!commercialOffer) {
+    return null
+  }
+
+  const { AvailableQuantity } = commercialOffer
+
+  if (hideWhenUnavailable({ showWhenUnavailable, AvailableQuantity })) {
     return null
   }
 
@@ -71,9 +75,7 @@ function SpotPriceSavings({
   }
 
   const containerClasses = withModifiers('spotPriceSavings', [
-    showWhenUnavailable && commercialOffer.AvailableQuantity <= 0
-      ? 'isUnavailable'
-      : '',
+    showWhenUnavailable && AvailableQuantity <= 0 ? 'isUnavailable' : '',
   ])
 
   return (

--- a/react/modules/hideWhenUnavailable.ts
+++ b/react/modules/hideWhenUnavailable.ts
@@ -1,0 +1,24 @@
+interface Props {
+  showWhenUnavailable: boolean
+  AvailableQuantity: number
+}
+/**
+ * hideWhenUnavailable -> Logic to hide or show block based on props passed by store theme
+ *
+ * @export
+ * @param {Props} {
+ *   showWhenUnavailable,
+ *   AvailableQuantity,
+ * }
+ * @returns {boolean}
+ */
+export function hideWhenUnavailable({
+  showWhenUnavailable,
+  AvailableQuantity,
+}: Props): boolean {
+  if (showWhenUnavailable) {
+    return false
+  }
+
+  return AvailableQuantity <= 0
+}


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This change was a request from `Philipspt` to the Western Europe team. The client want to display the product price and its variants (savings, list price, range price, etc) when the product is unavailable.

This versions add a prop called `showWhenUnavailable` to the following blocks. It defaults to `false`.

- `product-list-price`
- `product-selling-price`
- `product-spot-price`
- `product-spot-price-savings`
- `product-price-savings`
- `product-list-price-range`
- `product-selling-price-range`

It also adds a modified `--isUnavailable` class to their container so it can be target when product is unavailable.

I broke the checks to return `null` and skip render the block in two conditional statement. This way we can avoid having several conditionals check inside a `if` statement. I also added a reusable helper function `hideWhenUnavailable` to validate when to render the block.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[This workspace](https://unavailableprice--philipspt.myvtex.com/) has this branch linked. One can navigate in the home page to find an unavailable item displaying its price. It's also possible to find it working in [this product](https://unavailableprice--philipspt.myvtex.com/depiladora-philips-bri950-00-lumea-luz-pulsada-ipl-multi-zonas-smartskin-250-000-impulsos-2-acessorios/p).

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
First step, pass the new prop to the block in the store theme:

```json
{
  "product-list-price#summary": {
    "props": {
      "blockClass": "summary",
      "showWhenUnavailable": true
    }
  },
  "product-selling-price#summary": {
    "props": {
      "blockClass": "summary",
      "showWhenUnavailable": true
    }
  },
  "product-price-savings#summary": {
    "props": {
      "markers": [
        "discount"
      ],
      "blockClass": "summary",
      "showWhenUnavailable": true
    }
  },
  "product-price-savings": {
    "props": {
      "message": "{savingsPercentage}",
      "showWhenUnavailable": true
    }
  },
}

```

Then, you `product-list` should show the price product when it's unavailable, as the screen shot below:

<img width="1437" alt="Screen Shot 2021-07-01 at 12 08 20 PM" src="https://user-images.githubusercontent.com/38737958/124106997-12fc2a80-da65-11eb-8761-8051b2673c9e.png">


#### Describe alternatives you've considered, if any.

<!--- Optional -->
We - as the First Party Apps team in WE - thought about either creating a new block in the project or creating a new app to handle that.

For the first option, we would have to create a new block for every single one that shows price information - with the almost exactly same code. In the second approach, we would have to replicate the exactly same logic to cover all use and edge cases that `product-price` is already handling. This is why we went the route to add a prop to the current blocks.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/KZAavJr9mehCtlkdEH/giphy.gif)
